### PR TITLE
Fix template path to support Xcode 4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ Start hacking by modifying features/my_feature/feature.zucchini and features/sup
 
 Alternatively, check out the [zucchini-demo](https://github.com/rajbeniwal/zucchini-demo) project featuring an easy to explore Zucchini setup around Apple's CoreDataBooks sample.
 
+
+Xcode 4.2 and earlier
+--------------------------------
+With xcode 4.3 apple has moved the developer tools inside the xcode
+application.
+
+If you are using 4.2 or earlier then be sure to change the `template:` path in
+`config.yml`
+
+
 Running on the device
 --------------------------------
 Add your device to features/support/config.yml.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@ Run it as usual:
 ZUCCHINI_DEVICE="iOS Simulator" zucchini run /path/to/my_feature 
 ```
 
+Using #include statements with coffescript
+------------------------------------------
+UIAutomation gives you the extra ability to include outside scripts in your
+javascript using this syntax:
+
+    #include 'relative/path/to/javascript.js'
+
+The problem is that coffescript wants to turn this into a javascript comment.
+The way around this is to use [embedded javascript](http://coffeescript.org/#embedded).
+Just surround the statement with backticks and the coffescript compiler won't
+mess with it.
+
+
+    `#include "relative/path/to/javascript.js"`
+
+
 See also
 ---------
 ```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Xcode 4.2 and earlier
 With xcode 4.3 apple has moved the developer tools inside the xcode
 application.
 
-If you are using 4.2 or earlier then be sure to change the `template:` path in
+If you are using 4.2 then be sure to change the `template:` path in
 `config.yml`
 
 

--- a/templates/project/features/support/config.yml
+++ b/templates/project/features/support/config.yml
@@ -1,7 +1,9 @@
 app: MyApp.app
+
+# For Xcode 4.3 and later
 template: '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Instruments/PlugIns/AutomationInstrument.bundle/Contents/Resources/Automation.tracetemplate'
 
-# For Xcode < 4.3
+# For Xcode 4.2 uncomment the following line and comment out the previous one
 #template: '/Developer/Platforms/iPhoneOS.platform/Developer/Library/Instruments/PlugIns/AutomationInstrument.bundle/Contents/Resources/Automation.tracetemplate'
 
 devices:

--- a/templates/project/features/support/config.yml
+++ b/templates/project/features/support/config.yml
@@ -1,5 +1,8 @@
 app: MyApp.app
-template: '/Developer/Platforms/iPhoneOS.platform/Developer/Library/Instruments/PlugIns/AutomationInstrument.bundle/Contents/Resources/Automation.tracetemplate'
+template: '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Instruments/PlugIns/AutomationInstrument.bundle/Contents/Resources/Automation.tracetemplate'
+
+# For Xcode < 4.3
+#template: '/Developer/Platforms/iPhoneOS.platform/Developer/Library/Instruments/PlugIns/AutomationInstrument.bundle/Contents/Resources/Automation.tracetemplate'
 
 devices:
   My iDevice: 


### PR DESCRIPTION
The current template path does not support Xcode 4.3's new location for Instrument templates. This fixes that issue but it might be better to add an option to the `zucchini generate --project` command.
