### PR TITLE
Facilitate easier element hierarchy traversal with iOS 5+

### DIFF
--- a/lib/uia/base.coffee
+++ b/lib/uia/base.coffee
@@ -19,6 +19,15 @@ target = UIATarget.localTarget()
 app    = target.frontMostApp()
 view   = app.mainWindow()
 
+UIAElement.prototype.$ = (name) ->
+  target.pushTimeout(0)
+  elem = null
+  for el in this.elements()
+    elem = if el.name() == name then el else el.$(name)
+    break if elem
+  target.popTimeout()
+  elem
+
 target.waitForElement = (element) ->
   return  unless element
   found = false


### PR DESCRIPTION
iOS 5+ supports the new [`UIAccessibilityIdentification`](http://developer.apple.com/library/ios/#documentation/uikit/reference/UIAccessibilityIdentification_Protocol/Introduction/Introduction.html) protocol, which allows us to give visual elements meaningful names without confusing the voice-over accessibility tool. Traversing the hierarchy to find named elements is a bit clumsy, so I added this new method. 

For example, previously we had to do this

```
view.scrollViews()[0].elements()[0].elements()[0]
```

with a name we can do this:

```
view.scrollViews()[0].elements()[0].elements()["twitter"]
```

but with the addition in this pull request we can do:

```
view.$("twitter")
```

This allows us to disentangle the element in question from the specific hierarchy required to get there (i.e. implementation details)
