### PR TITLE
Adds the ability to choose between iPhone or iPad (low and retina) simulators when working with a universal app

### DIFF
--- a/lib/config.rb
+++ b/lib/config.rb
@@ -29,7 +29,9 @@ module Zucchini
       {
         :name   => device_name,
         :udid   => device['UDID'],
-        :screen => device['screen']
+        :screen => device['screen'],
+        :simfamily  => device['simfamily'],
+        :simOS => device['simOS']
       }
     end
     

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -30,8 +30,7 @@ module Zucchini
         :name   => device_name,
         :udid   => device['UDID'],
         :screen => device['screen'],
-        :simfamily  => device['simfamily'],
-        :simOS => device['simOS']
+        :simfamily  => device['simfamily']
       }
     end
     

--- a/lib/feature.rb
+++ b/lib/feature.rb
@@ -61,7 +61,10 @@ class Zucchini::Feature
       `rm -rf #{run_data_path}/*`
       compile_js
     
-      device_params = (@device[:name] == "iOS Simulator") ? "" : "-w #{@device[:udid]}"
+      device_params = ""
+      if(@device[:name] != "iOS Simulator")
+        device_params = "-w #{@device[:udid]}"
+      end
       
       begin
         out = `instruments #{device_params} -t #{@template} #{Zucchini::Config.app} -e UIASCRIPT #{run_data_path}/feature.js -e UIARESULTSPATH #{run_data_path} 2>&1`


### PR DESCRIPTION
When using Zucchini with Universal apps, the simulator always runs as an iPad.  This adds support for specifying which device, and at what resolution, the simulator should use when running a test.
## Usage

Simply specify a 'simfamily' value in your config.yml file for your iOS Simulator device - either iPhone or iPad

``` devices:
  iOS Simulator: 
    screen: low_ios5
    simfamily: iPhone
```

Screen resolution is determined by the screen value, in this case, low.
