### PR TITLE
Fixed config to accept relative path to app

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ Running on the iOS Simulator
 -------------------------------
 We strongly encourage you to run your Zucchini features on real hardware. However, you can run them on the iOS Simulator if you must.
 
-First off, modify your features/support/config.yml to include a full path to your compiled app, e.g.
+First off, modify your features/support/config.yml to include the path to your compiled app, e.g.
 
 ```
-app: /Users/vaskas/Library/Developer/Xcode/DerivedData/CoreDataBooks-ebeqiuqksrwwoscupvxuzjzrdfjz/Build/Products/Debug-iphonesimulator/CoreDataBooks.app
+app: ./Build/Products/Debug-iphonesimulator/CoreDataBooks.app
 ```
 
 Secondly, add an 'iOS Simulator' entry to the devices section (no UDID needed) and make sure you provide the actual value for 'screen' based on your iOS Simulator settings:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ devices:
     screen: low_ios5
 ```
 
+Alternatively, you can specify the app path in the device section:
+
+```
+devices:
+  iOS Simulator:
+    screen: low_ios5
+    app: ./Build/Products/Debug-iphonesimulator/CoreDataBooks.app
+  iPad2:
+    screen: ipad_ios5
+    app: ./Build/Products/Debug-iphoneos/CoreDataBooks.app
+```
+
+
 Run it as usual:
 
 ```

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -13,7 +13,7 @@ module Zucchini
     end
                   
     def self.app
-      File.absolute_path(@@config['app'])
+      File.absolute_path( devices[ENV['ZUCCHINI_DEVICE']]['app'] || @@config['app'] )
     end
   
     def self.resolution_name(dimension)   

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -13,7 +13,7 @@ module Zucchini
     end
                   
     def self.app
-      @@config['app']
+      File.absolute_path(@@config['app'])
     end
   
     def self.resolution_name(dimension)   


### PR DESCRIPTION
Giving an absolute path to the app is problematic when the testing has to be done in different environments and/or user directories.

This fix let the config accept a relative path as well as the absolute path to app.
## 

AC
